### PR TITLE
Small enhancements: Redirect after Oauth, optional <title> for declare

### DIFF
--- a/app/controllers/concerns/slack/constants.rb
+++ b/app/controllers/concerns/slack/constants.rb
@@ -5,5 +5,6 @@ module Slack
     extend ActiveSupport::Concern
 
     CREATE_INCIDENT_MODAL_CALLBACK_ID = "declare-incident-modal"
+    SLACK_URL = "https://slack.com"
   end
 end

--- a/app/controllers/slack/commands_controller.rb
+++ b/app/controllers/slack/commands_controller.rb
@@ -12,7 +12,7 @@ module Slack
     # @see https://www.rubydoc.info/docs/rails/3.2.8/ActionView/Helpers/DateHelper:distance_of_time_in_words
     def create
       return json_error_response unless params[:text].present?
-      text_command, text_payload = params[:text].split(" ", 2)
+      text_command, text_payload = params[:text].split(" ", 2) || ""
 
       case text_command
       when "declare"

--- a/app/controllers/slack/oauth_callbacks_controller.rb
+++ b/app/controllers/slack/oauth_callbacks_controller.rb
@@ -5,6 +5,8 @@ module Slack
   # @see https://api.slack.com/authentication/oauth-v2#exchanging
   # @see https://api.slack.com/methods/oauth.v2.access
   class OauthCallbacksController < ApplicationController
+    include Slack::Constants
+
     def new
       return head 400 if session[:state] != params[:state]
 
@@ -25,7 +27,7 @@ module Slack
 
         # Subsequent oauth attempts update access_token
         if slack_team.update(access_token: result[:access_token])
-          head :ok
+          redirect_to "#{SLACK_URL}/app_redirect?channel=general", allow_other_host: true
         else
           head 500
         end

--- a/test/controllers/slack/oauth_callbacks_controller_test.rb
+++ b/test/controllers/slack/oauth_callbacks_controller_test.rb
@@ -90,6 +90,7 @@ module Slack
           slack_team = SlackTeam.find_by(external_team_id: team_id)
 
           assert_equal "my_token", slack_team.access_token
+          assert_redirected_to "https://slack.com/app_redirect?channel=general"
         end
       end
 
@@ -138,6 +139,7 @@ module Slack
           slack_team = SlackTeam.find_by(external_team_id: team_id)
 
           assert_equal "updated_token", slack_team.access_token
+          assert_redirected_to "https://slack.com/app_redirect?channel=general"
         end
       end
     end


### PR DESCRIPTION
* Redirect after OAuth flow finishes
* Small tweak to `/rootly declare <title>` to allow for optional <title>